### PR TITLE
refactor: exclude cli from typescript compilation

### DIFF
--- a/.changeset/modern-boxes-develop.md
+++ b/.changeset/modern-boxes-develop.md
@@ -1,0 +1,7 @@
+---
+"@darkflare/wjson": patch
+---
+
+refactor: exclude cli from typescript compilation
+
+Exclude CLI file from TypeScript compilation to reduce package size. No change for users since the code is internal anyway.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   },
   "exclude": [
     "test",
-    "types"
+    "types",
+    "src/bin"
   ]
 }


### PR DESCRIPTION
Exclude CLI file from TypeScript compilation to reduce package size. No change for users since the code is internal anyway.